### PR TITLE
Mucking about with themes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,4 +10,4 @@ github_username:  ebassett
 
 show_excerpts: true # set to false to remove excerpts on the homepage
 
-theme: jekyll-theme-midnight
+theme: minima


### PR DESCRIPTION
The GitHub Learning Lab's GitHub Pages course says to manually edit the _config.yml file to change the theme (from my initial choice - via the GitHub website's Settings page - of "jekyll-theme-midnight" to "minima".
I *guessed* that this meant I should actually type "jekyll-theme-minima".
Incorrectly, as it turns out.
And the only indication I got that I was trying to apply an invalid/non-existent theme was an email:
  You are attempting to use a Jekyll theme, "jekyll-theme-minima", which is not supported by GitHub Pages.
  Please visit https://pages.github.com/themes/ for a list of supported themes.
(Well, and possibly the fact that the resulting page was not clearly themed at all; but maybe that's just what they wanted a theme called "minima" to look like!)
My confusion was compounded by the fact that one of the themes displayed in the GitHub website settings page for GitHub Pages has a theme called "Minimal" - with an 'l' on the end - that does in fact include the "jekyll-theme-" prefix: jekyll-theme-minimal.
I have confirmed (previous commit) that that last theme text works.
Now I am going to confirm "theme: minima"...